### PR TITLE
Avoid caching DNS responses without TTL

### DIFF
--- a/handler.go
+++ b/handler.go
@@ -156,6 +156,9 @@ func (h *DNSHandler) makekey(q *dns.Question) cachesKey {
 }
 
 func (h *DNSHandler) getMinTTL(msg *dns.Msg) uint32 {
+	if len(msg.Answer) == 0 {
+		return 0
+	}
 	minTTL := uint32(MaxTTL)
 	for _, rr := range msg.Answer {
 		if rr.Header().Ttl < minTTL {


### PR DESCRIPTION
## Summary
- skip caching when DNS responses have no answer records by returning TTL 0

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68a7f01c05e88333a1fa18922aa03b50