### PR TITLE
Add tests for domainToDNSBytes

### DIFF
--- a/handler_test.go
+++ b/handler_test.go
@@ -1,0 +1,25 @@
+package main
+
+import (
+	"bytes"
+	"testing"
+)
+
+func TestDomainToDNSBytes(t *testing.T) {
+	h := &DNSHandler{}
+	want := []byte{3, 'w', 'w', 'w', 7, 'e', 'x', 'a', 'm', 'p', 'l', 'e', 3, 'c', 'o', 'm', 0}
+
+	t.Run("with trailing dot", func(t *testing.T) {
+		got := h.domainToDNSBytes("www.example.com.")
+		if !bytes.Equal(got, want) {
+			t.Fatalf("domainToDNSBytes with trailing dot got %v, want %v", got, want)
+		}
+	})
+
+	t.Run("without trailing dot", func(t *testing.T) {
+		got := h.domainToDNSBytes("www.example.com")
+		if !bytes.Equal(got, want) {
+			t.Fatalf("domainToDNSBytes without trailing dot got %v, want %v", got, want)
+		}
+	})
+}


### PR DESCRIPTION
## Summary
- add coverage for domainToDNSBytes
- ensure domains with and without trailing dots produce correct DNS wire format bytes

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68a7f30304b48333862b938e7ab9e218